### PR TITLE
Don't ignore bytes beyond the terminating null byte

### DIFF
--- a/pfile_tools/struct_utils.py
+++ b/pfile_tools/struct_utils.py
@@ -59,6 +59,10 @@ def set_struct_value(struct, field_name, value):
         subhead_key = parts[0]
         parts = parts[1:]
         sh = getattr(sh, subhead_key)
+    # clear the field completely before setting it
+    field = getattr(type(sh), parts[0])
+    dummy = ctypes.c_char*field.size
+    dummy.from_buffer(sh, field.offset).raw = b'\0'*field.size
     setattr(sh, parts[0], value)
 
 

--- a/pfile_tools/struct_utils.py
+++ b/pfile_tools/struct_utils.py
@@ -38,6 +38,13 @@ def _dump_struct_rec(
         field_type = f[1]
         field_meta = getattr(struct_class, name)
         field = getattr(struct, name)
+        if type(field) == type(b''):
+            # replace null bytes with '@' to make them visible
+            a = getattr(type(struct), name)
+            dummy = ctypes.c_char*a.size
+            field = dummy.from_buffer(struct, a.offset).raw
+            field = field.rstrip('\0')
+            field = field.replace('\0', '@')
         cur_prefix = "%s%s." % (prefix, name)
         field_offset = base_offset + field_meta.offset
         if isinstance(field, ctypes.Structure):


### PR DESCRIPTION
The pfiles use fixed-width string fields, but when Python ctypes inserts a new string into these fields, it only modifies the characters up to the null byte of the inserted string.  This means that sensitive information might remain which would be visible to anyone who did a binary dump of the files.

These patches change the behavior so that 1) the field is fully cleared before the new data is inserted and 2) when the pfile is printed, the full string fields are printed, including any characters beyond the null.  For example "John Doe" will be printed if there are no non-null characters after the name, but "John Doe@Kreicwicz" will be printed if the null (printed as "@") is followed by non-null characters (I chose to use "@" to signify "null" because it looks vaguely like a zero).